### PR TITLE
Fix i18n import path and chart type typings

### DIFF
--- a/src/components/ChartRoutes.tsx
+++ b/src/components/ChartRoutes.tsx
@@ -3,16 +3,16 @@ import { Routes, Route, Navigate, useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import ChartRenderer from "./ChartRenderer";
 import { RootState } from "../store/store";
-import { setChartType } from "../store/chartSlice";
+import { setChartType, ChartType } from "../store/chartSlice";
 
 const ChartRoute: React.FC = () => {
-  const { type } = useParams<{ type: string }>();
+  const { type } = useParams<{ type: ChartType }>();
   const dispatch = useDispatch();
   const chartConfigs = useSelector((state: RootState) => state.chart.chartConfigs);
 
   useEffect(() => {
     if (type) {
-      dispatch(setChartType(type as any));
+      dispatch(setChartType(type));
     }
   }, [type, dispatch]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import { Provider } from "react-redux";
 import { store } from "./store/store";
 import App from "./App";
-import "./i18n";
+import "./i18n/i18n";
 import "antd/dist/reset.css";
 import "./index.css";
 

--- a/src/store/chartSlice.ts
+++ b/src/store/chartSlice.ts
@@ -291,6 +291,17 @@ interface ChartConfig {
   };
 }
 
+type ChartType =
+  | "column"
+  | "pie"
+  | "line"
+  | "stackedColumn"
+  | "clusteredColumn"
+  | "lineAndColumn"
+  | "bar"
+  | "stackedBar"
+  | "clusteredBar";
+
 interface ChartState {
   data: typeof sampleData;
   categoryData: typeof categoryData;
@@ -298,14 +309,7 @@ interface ChartState {
   populationData: typeof populationData;
   testStackedData: typeof testStackedData;
   selectedData: any[]; // Dữ liệu được chọn từ chart
-  chartType:
-    | "line"
-    | "pie"
-    | "stackedColumn"
-    | "clusteredColumn"
-    | "lineAndColumn"
-    | "stackedBar"
-    | "clusteredBar";
+  chartType: ChartType;
   activeTab: "data" | "format";
   activeSubTab: "Visual" | "General";
   expandedSections: {
@@ -1055,18 +1059,7 @@ const chartSlice = createSlice({
     setRawChartData: (state, action: PayloadAction<any[]>) => {
       state.rawChartData = action.payload;
     },
-    setChartType: (
-      state,
-      action: PayloadAction<
-        | "line"
-        | "pie"
-        | "stackedColumn"
-        | "clusteredColumn"
-        | "lineAndColumn"
-        | "stackedBar"
-        | "clusteredBar"
-      >
-    ) => {
+    setChartType: (state, action: PayloadAction<ChartType>) => {
       state.chartType = action.payload;
     },
     setSelectedData: (state, action: PayloadAction<any[]>) => {
@@ -1149,5 +1142,5 @@ export const {
   updateFormatConfig,
 } = chartSlice.actions;
 
-export type { ChartState };
+export type { ChartState, ChartType };
 export default chartSlice.reducer;


### PR DESCRIPTION
## Summary
- fix missing i18n import path so build can resolve translations
- add ChartType union and use it in routes and reducer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a57d465fb883289bd8ac628f480363